### PR TITLE
Add configurable MongoDB URI

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -6,3 +6,7 @@ Currently, two official plugins are available:
 
 - [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/README.md) uses [Babel](https://babeljs.io/) for Fast Refresh
 - [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+
+## Environment variables
+
+Copy `.env.example` to `.env` inside `src/` and edit the values as needed. The `MONGODB_URI` variable controls the MongoDB connection string used by the server.

--- a/backend/src/.env.example
+++ b/backend/src/.env.example
@@ -1,0 +1,3 @@
+JWT_SECRET=your_jwt_secret
+JWT_EXPIRATION=1h
+MONGODB_URI=mongodb://localhost:27017/NuevoPrueba

--- a/backend/src/db.js
+++ b/backend/src/db.js
@@ -1,9 +1,12 @@
 // db.js
 import mongoose from 'mongoose';
 
+const DEFAULT_URI = "mongodb://localhost:27017/NuevoPrueba";
+
 export const connectDB = async () => {
+    const uri = process.env.MONGODB_URI || DEFAULT_URI;
     try {
-        await mongoose.connect("mongodb://localhost:27017/NuevoPrueba", {
+        await mongoose.connect(uri, {
             useNewUrlParser: true,
             useUnifiedTopology: true,
         });


### PR DESCRIPTION
## Summary
- allow setting MongoDB connection with `MONGODB_URI`
- document environment variable usage
- provide `.env.example` with defaults

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b06014948832bb934ee1da8104095