### PR TITLE
Add API URL env variable

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,3 @@
+# Example environment configuration for Vite
+# Base URL for backend API
+VITE_API_URL=http://localhost:5000

--- a/frontend/src/estructura/ActualizarProducto.jsx
+++ b/frontend/src/estructura/ActualizarProducto.jsx
@@ -14,7 +14,7 @@ const ActualizarProducto = () => {
   useEffect(() => {
     const fetchProductos = async () => {
       try {
-        const response = await fetch('http://localhost:5000/api/productos');
+        const response = await fetch(`${import.meta.env.VITE_API_URL}/api/productos`);
         if (response.ok) {
           const data = await response.json();
           setProductos(data);
@@ -33,7 +33,7 @@ const ActualizarProducto = () => {
     if (productoSeleccionado) {
       const fetchProducto = async () => {
         try {
-          const response = await fetch(`http://localhost:5000/api/productos/${productoSeleccionado}`);
+          const response = await fetch(`${import.meta.env.VITE_API_URL}/api/productos/${productoSeleccionado}`);
           if (response.ok) {
             const producto = await response.json();
             setNombre(producto.nombre);
@@ -69,7 +69,7 @@ const ActualizarProducto = () => {
       formData.append('categoria', categoria);
       if (foto && typeof foto !== 'string') formData.append('imagen', foto);
 
-      const response = await fetch(`http://localhost:5000/api/productos/${productoSeleccionado}`, {
+      const response = await fetch(`${import.meta.env.VITE_API_URL}/api/productos/${productoSeleccionado}`, {
         method: 'PUT',
         body: formData,
       });
@@ -90,7 +90,7 @@ const ActualizarProducto = () => {
     if (!confirmDelete) return;
 
     try {
-      const response = await fetch(`http://localhost:5000/api/productos/${productoSeleccionado}`, {
+      const response = await fetch(`${import.meta.env.VITE_API_URL}/api/productos/${productoSeleccionado}`, {
         method: 'DELETE',
       });
 
@@ -165,7 +165,7 @@ const ActualizarProducto = () => {
           />
           <input type="file" onChange={handleFileChange} className="mb-4" accept="image/*" />
           {foto && typeof foto === 'string' && (
-            <img src={`http://localhost:5000${foto}`} alt="Imagen actual" className="w-32 h-32 object-cover mb-4" />
+            <img src={`${import.meta.env.VITE_API_URL}${foto}`} alt="Imagen actual" className="w-32 h-32 object-cover mb-4" />
           )}
           {foto && typeof foto !== 'string' && (
             <img src={URL.createObjectURL(foto)} alt="Vista previa" className="w-32 h-32 object-cover mb-4" />

--- a/frontend/src/estructura/AdminComentarios.jsx
+++ b/frontend/src/estructura/AdminComentarios.jsx
@@ -8,7 +8,7 @@ const AdminComentarios = () => {
 
   const obtenerComentarios = async () => {
     try {
-      const res = await fetch('http://localhost:5000/api/comentarios');
+      const res = await fetch(`${import.meta.env.VITE_API_URL}/api/comentarios`);
       const data = await res.json();
       setComentarios(data);
     } catch (err) {
@@ -20,7 +20,7 @@ const AdminComentarios = () => {
 
   const aprobarComentario = async (id, aprobado) => {
     try {
-      const res = await fetch(`http://localhost:5000/api/comentarios/${id}/aprobar`, {
+      const res = await fetch(`${import.meta.env.VITE_API_URL}/api/comentarios/${id}/aprobar`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ aprobado }),

--- a/frontend/src/estructura/AgregarProducto.jsx
+++ b/frontend/src/estructura/AgregarProducto.jsx
@@ -34,7 +34,7 @@ const AgregarProducto = () => {
       formData.append('imagen', foto);
 
       // Hacer la solicitud al backend
-      const response = await fetch('http://localhost:5000/api/productos', {
+      const response = await fetch(`${import.meta.env.VITE_API_URL}/api/productos`, {
         method: 'POST',
         body: formData,
       });

--- a/frontend/src/estructura/AsignarRoles.jsx
+++ b/frontend/src/estructura/AsignarRoles.jsx
@@ -9,7 +9,7 @@ function AsignarRoles() {
 
   // Cargar lista de usuarios
   useEffect(() => {
-    fetch("http://localhost:5000/api/usuarios")
+    fetch(`${import.meta.env.VITE_API_URL}/api/usuarios`)
       .then((res) => res.json())
       .then((data) => {
         setUsuarios(data);
@@ -22,7 +22,7 @@ function AsignarRoles() {
   }, []);
 
   const actualizarRol = (id, nuevoRol) => {
-    fetch(`http://localhost:5000/api/actualizar-rol/${id}`, {
+    fetch(`${import.meta.env.VITE_API_URL}/api/actualizar-rol/${id}`, {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ rol: nuevoRol }),

--- a/frontend/src/estructura/Catalogo.jsx
+++ b/frontend/src/estructura/Catalogo.jsx
@@ -23,7 +23,7 @@ const Catalogo = () => {
   useEffect(() => {
     const fetchProductos = async () => {
       try {
-        const response = await fetch('http://localhost:5000/api/productos');
+        const response = await fetch(`${import.meta.env.VITE_API_URL}/api/productos`);
         const data = await response.json();
         setProductos(data);
       } catch (error) {
@@ -130,7 +130,7 @@ const Catalogo = () => {
             className="bg-white dark:bg-gray-800 p-4 rounded-lg shadow-md text-center text-black dark:text-white"
           >
             <img
-              src={`http://localhost:5000${producto.imagen}`}
+              src={`${import.meta.env.VITE_API_URL}${producto.imagen}`}
               alt={producto.nombre}
               className="w-48 h-auto mx-auto mb-4"
             />

--- a/frontend/src/estructura/Comandas.jsx
+++ b/frontend/src/estructura/Comandas.jsx
@@ -7,7 +7,7 @@ const Comandas = () => {
 
   // Obtener comandas
   useEffect(() => {
-    fetch("http://localhost:5000/api/pedidos/comandas")
+    fetch(`${import.meta.env.VITE_API_URL}/api/pedidos/comandas`)
       .then((res) => {
         if (!res.ok) {
           throw new Error("No se pudieron cargar las comandas.");
@@ -26,7 +26,7 @@ const Comandas = () => {
 
   // Actualizar estado de una comanda
   const actualizarEstado = (id, nuevoEstado) => {
-    fetch(`http://localhost:5000/api/pedidos/${id}`, {
+    fetch(`${import.meta.env.VITE_API_URL}/api/pedidos/${id}`, {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ estado: nuevoEstado }),

--- a/frontend/src/estructura/EstadoPedido.jsx
+++ b/frontend/src/estructura/EstadoPedido.jsx
@@ -18,7 +18,7 @@ const MisPedidos = () => {
   useEffect(() => {
     const fetchPedidos = async () => {
       try {
-        const res = await fetch(`http://localhost:5000/api/pedidos/usuario/${user.email}`);
+        const res = await fetch(`${import.meta.env.VITE_API_URL}/api/pedidos/usuario/${user.email}`);
         const data = await res.json();
         setPedidos(data);
       } catch (err) {
@@ -62,7 +62,7 @@ const MisPedidos = () => {
     console.log("Enviando comentario:", payload);
 
     try {
-      const res = await fetch(`http://localhost:5000/api/comentarios`, {
+      const res = await fetch(`${import.meta.env.VITE_API_URL}/api/comentarios`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(payload),

--- a/frontend/src/estructura/LoginForm.jsx
+++ b/frontend/src/estructura/LoginForm.jsx
@@ -24,7 +24,7 @@ function LoginForm() {
     setLoading(true);
     setErrorMessage("");
     try {
-      const response = await fetch("http://localhost:5000/api/auth/login", {
+      const response = await fetch(`${import.meta.env.VITE_API_URL}/api/auth/login`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(data),
@@ -53,7 +53,7 @@ function LoginForm() {
       return;
     }
     try {
-      const res = await fetch("http://localhost:5000/api/enviar-codigo", {
+      const res = await fetch(`${import.meta.env.VITE_API_URL}/api/enviar-codigo`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ email }),
@@ -89,7 +89,7 @@ function LoginForm() {
     try {
       if (!data.newPassword) throw new Error("Ingresa una nueva contraseña");
 
-      const res = await fetch("http://localhost:5000/api/auth/login/reset-password", {
+      const res = await fetch(`${import.meta.env.VITE_API_URL}/api/auth/login/reset-password`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -132,7 +132,7 @@ function LoginForm() {
                 <input
                   type="email"
                   className="w-full p-3 border rounded"
-                  {...register("email", { required: "El correo electrónico es obligatorio" })}
+                  {...register("email`, { required: "El correo electrónico es obligatorio" })}
                 />
                 {errors.email && <p className="text-red-500 text-sm mt-1">{errors.email.message}</p>}
               </div>
@@ -141,7 +141,7 @@ function LoginForm() {
                 <input
                   type="password"
                   className="w-full p-3 border rounded"
-                  {...register("password", { required: "La contraseña es obligatoria" })}
+                  {...register("password`, { required: "La contraseña es obligatoria" })}
                 />
                 {errors.password && <p className="text-red-500 text-sm mt-1">{errors.password.message}</p>}
               </div>
@@ -235,7 +235,7 @@ function LoginForm() {
                 type="password"
                 placeholder="Nueva contraseña"
                 className="w-full p-3 border rounded mb-3"
-                {...register("newPassword", { required: "La contraseña es obligatoria" })}
+                {...register("newPassword`, { required: "La contraseña es obligatoria" })}
               />
               {errors.newPassword && <p className="text-red-500 mb-2">{errors.newPassword.message}</p>}
               {errorMessage && <p className="text-red-500 mb-2">{errorMessage}</p>}

--- a/frontend/src/estructura/Pago.jsx
+++ b/frontend/src/estructura/Pago.jsx
@@ -99,7 +99,7 @@ const Pago = () => {
     setLoading(true);
     const total = calcularTotalConDelivery();
     try {
-      const response = await fetch("http://localhost:5000/api/pedidos", {
+      const response = await fetch(`${import.meta.env.VITE_API_URL}/api/pedidos`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ usuario: user, carrito: cart, total, direccion }),

--- a/frontend/src/estructura/RegistroForm.jsx
+++ b/frontend/src/estructura/RegistroForm.jsx
@@ -24,7 +24,7 @@ function RegistroForm() {
       return;
     }
 
-    fetch("http://localhost:5000/api/enviar-codigo", {
+    fetch(`${import.meta.env.VITE_API_URL}/api/enviar-codigo`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ email }),
@@ -60,7 +60,7 @@ function RegistroForm() {
       password: data.password,
     };
 
-    fetch("http://localhost:5000/api/auth/registro", {
+    fetch(`${import.meta.env.VITE_API_URL}/api/auth/registro`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(jsonData),

--- a/frontend/src/estructura/ReporteVentas.jsx
+++ b/frontend/src/estructura/ReporteVentas.jsx
@@ -18,7 +18,7 @@ const ReporteVentas = () => {
     setError(null);
     try {
       const response = await fetch(
-        `http://localhost:5000/api/pedidos/ventas?startDate=${startDate}&endDate=${endDate}`
+        `${import.meta.env.VITE_API_URL}/api/pedidos/ventas?startDate=${startDate}&endDate=${endDate}`
       );
       if (!response.ok) throw new Error("Error al obtener los datos de ventas.");
       const data = await response.json();


### PR DESCRIPTION
## Summary
- add `.env.example` with `VITE_API_URL`
- swap hard-coded localhost links in catalog components for `${import.meta.env.VITE_API_URL}`

## Testing
- `npm test` *(fails: missing script)*
- `npm test` in backend *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685b06332ffc832bad9d597633e65eb6