### PR TITLE
Clean backend Vite remnants

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -13,17 +13,11 @@ npm run dev
 ```
 
 The server listens on the port defined in the `.env` file or `5000` by default.
-=======
-
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/README.md) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
 
 ## Running in production
 
-Build the application and start the server using the following commands:
+Start the server with Node:
 
 ```bash
-npm run build
 npm start
 ```
-

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,8 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "nodemon src/index.js",
-    "start": "node src/index.js",
-    "build": "vite build"
+    "start": "node src/index.js"
   },
   "dependencies": {
     "bcrypt": "^5.1.1",


### PR DESCRIPTION
## Summary
- remove unused Vite build script from backend
- clean up backend README documentation

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_685c85b375fc832bb452b4a388b25983