### PR TITLE
docs: clarify frontend env setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,10 @@ This repository contains two separate applications:
      JWT_EXPIRATION=1h
      PORT=5000 # optional, defaults to 5000
      ```
-   - Update MongoDB connection string in `backend/src/db.js` if needed.
+  - Update MongoDB connection string in `backend/src/db.js` if needed.
+  - Copy `frontend/.env.example` to `frontend/.env` and set
+    `VITE_API_BASE_URL` to the base URL of your backend API
+    (for example `https://proyecto-produccion-df62.up.railway.app`).
 3. Start development servers:
    - Backend: `npm run dev` inside `backend`.
    - Frontend: `npm run dev` inside `frontend`.

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,3 +1,5 @@
 # Example environment configuration for Vite
 # Base URL for backend API
 VITE_API_BASE_URL=http://localhost:5000
+# Replace with your production API base URL during deployment
+# e.g. VITE_API_BASE_URL=https://proyecto-produccion-df62.up.railway.app

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -11,7 +11,17 @@ This directory contains the React application built with Vite.
 
 ## Configuration
 
-API requests use the `API_BASE` constant exported from `src/config.js`. Create a `.env` file based on the provided `.env.example` and set `VITE_API_BASE_URL` to the base URL of your backend API.
+API requests use the `API_BASE` constant exported from `src/config.js`. Create a
+`.env` file based on the provided `.env.example` and set `VITE_API_BASE_URL` to
+the base URL of your backend API.
+
+For production deployments you can set it to your Railway backend, for example:
+
+```bash
+VITE_API_BASE_URL=https://proyecto-produccion-df62.up.railway.app
+```
+
+The `.env.example` file keeps the localhost URL for local development.
 
 Run the development server with hot reload:
 


### PR DESCRIPTION
## Summary
- document how to create `.env` for the frontend with the production API URL
- emphasize this env variable in frontend README
- add a helpful comment to `.env.example`

## Testing
- `npm run build` *(fails: Could not resolve "../imagenes/logoSushi.jpg" from RegistroForm.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_685ccf17a03c832b8c4be20b93c0cc0c