### PR TITLE
Add dev proxy configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,10 @@ This repository contains two separate applications:
      ```
   - Update MongoDB connection string in `backend/src/db.js` if needed.
   - Copy `frontend/.env.example` to `frontend/.env` and set
-    `VITE_API_BASE_URL` to the base URL of your backend API
-    (for example `https://proyecto-produccion-df62.up.railway.app`).
+    `VITE_API_BASE_URL` to the base URL of your backend API. During
+    development the Vite dev server will proxy requests starting with
+    `/api` to this URL (for example
+    `https://proyecto-produccion-df62.up.railway.app`).
 3. Start development servers:
    - Backend: `npm run dev` inside `backend`.
    - Frontend: `npm run dev` inside `frontend`.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -11,9 +11,10 @@ This directory contains the React application built with Vite.
 
 ## Configuration
 
-API requests use the `API_BASE` constant exported from `src/config.js`. Create a
-`.env` file based on the provided `.env.example` and set `VITE_API_BASE_URL` to
-the base URL of your backend API.
+API requests use the `API_BASE` constant exported from `src/config.js`, which is
+set to `/api`. Create a `.env` file based on the provided `.env.example` and set
+`VITE_API_BASE_URL` to the base URL of your backend API. The development server
+will proxy calls to `/api` to this URL.
 
 For production deployments you can set it to your Railway backend, for example:
 

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -1,1 +1,5 @@
-export const API_BASE = import.meta.env.VITE_API_BASE_URL;
+// Base path for API requests.
+// During development, Vite proxies `/api` to the backend URL defined
+// in the `VITE_API_BASE_URL` environment variable.
+// In production `/api` should be served by your reverse proxy/backend.
+export const API_BASE = '/api';

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,7 +1,18 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 
 // https://vitejs.dev/config/
-export default defineConfig({
-  plugins: [react()],
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '')
+  return {
+    plugins: [react()],
+    server: {
+      proxy: {
+        '/api': {
+          target: env.VITE_API_BASE_URL || 'http://localhost:5000',
+          changeOrigin: true,
+        },
+      },
+    },
+  }
 })


### PR DESCRIPTION
## Summary
- update README to mention proxy usage
- mention proxy config in frontend README
- use `/api` path for API calls
- configure Vite dev server proxy

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685db87dde18832ba040ac2ad062b104